### PR TITLE
Improve number combo display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # jack-combos
-A project to provide combinations for tickets
+
+This repository hosts a small web application for generating combinations from selected numbers. The site lives in the `docs/` folder so it can be served with [GitHub Pages](https://pages.github.com/).
+Use the **System selection** dropdown to choose how many numbers to pick (from 7
+to 35). After filling out the subsequent number selectors, pressing **GO**
+displays every 7-number combination of the chosen values.
+
+## Running locally
+Open `docs/index.html` in your browser. No build step is required.
+
+## GitHub Pages
+Enable GitHub Pages in the repository settings and select the `docs/` directory as the source. After a few minutes your site will be available at:
+```
+https://<username>.github.io/jack-combos/
+```
+Replace `<username>` with your GitHub user name.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Number Combinations</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Number Combinations</h1>
+    <label for="comboSize" class="block">System selection</label>
+    <select id="comboSize">
+      <option value="" disabled selected>Select...</option>
+    </select>
+    <div id="number-selects"></div>
+    <button id="goButton" disabled>GO</button>
+    <pre id="results"></pre>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,96 @@
+const comboSizeSelect = document.getElementById('comboSize');
+const selectsContainer = document.getElementById('number-selects');
+const goButton = document.getElementById('goButton');
+const resultsPre = document.getElementById('results');
+const MAX_NUMBER = 35;
+
+// populate first dropdown
+for (let i = 7; i <= MAX_NUMBER; i++) {
+  const opt = document.createElement('option');
+  opt.value = i;
+  opt.textContent = i;
+  comboSizeSelect.appendChild(opt);
+}
+
+comboSizeSelect.addEventListener('change', () => {
+  const count = parseInt(comboSizeSelect.value, 10);
+  selectsContainer.innerHTML = '';
+  resultsPre.textContent = '';
+  goButton.disabled = true;
+
+  for (let i = 0; i < count; i++) {
+    const label = document.createElement('label');
+    label.textContent = `Number ${i + 1}`;
+    const select = document.createElement('select');
+    select.dataset.index = i;
+    select.disabled = i !== 0;
+    select.addEventListener('change', onNumberChange);
+    label.appendChild(select);
+    selectsContainer.appendChild(label);
+  }
+  populateSelect(0);
+});
+
+function onNumberChange(e) {
+  const index = parseInt(e.target.dataset.index, 10);
+  const next = selectsContainer.querySelector(`select[data-index="${index + 1}"]`);
+  if (next) {
+    next.disabled = false;
+    populateSelect(index + 1);
+  }
+  // repopulate following selects to avoid duplicates
+  const total = selectsContainer.querySelectorAll('select').length;
+  for (let i = index + 1; i < total; i++) {
+    populateSelect(i);
+  }
+  checkReady();
+}
+
+function populateSelect(index) {
+  const select = selectsContainer.querySelector(`select[data-index="${index}"]`);
+  if (!select) return;
+  const used = Array.from(selectsContainer.querySelectorAll('select'))
+    .slice(0, index)
+    .map(s => parseInt(s.value, 10))
+    .filter(v => !isNaN(v));
+  select.innerHTML = '<option value="" disabled selected>Select...</option>';
+  for (let i = 1; i <= MAX_NUMBER; i++) {
+    if (!used.includes(i)) {
+      const opt = document.createElement('option');
+      opt.value = i;
+      opt.textContent = i;
+      select.appendChild(opt);
+    }
+  }
+}
+
+function checkReady() {
+  const allSelected = Array.from(selectsContainer.querySelectorAll('select'))
+    .every(sel => sel.value);
+  goButton.disabled = !allSelected;
+}
+
+function getCombinations(arr, k) {
+  const results = [];
+  const combo = [];
+  function helper(start) {
+    if (combo.length === k) {
+      results.push(combo.slice());
+      return;
+    }
+    for (let i = start; i < arr.length; i++) {
+      combo.push(arr[i]);
+      helper(i + 1);
+      combo.pop();
+    }
+  }
+  helper(0);
+  return results;
+}
+
+goButton.addEventListener('click', () => {
+  const numbers = Array.from(selectsContainer.querySelectorAll('select'))
+    .map(s => parseInt(s.value, 10));
+  const combos = getCombinations(numbers, 7);
+  resultsPre.textContent = combos.map(c => c.join(', ')).join('\n');
+});

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,38 @@
+body {
+  font-family: Arial, sans-serif;
+  font-size: 20px;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 600px;
+  margin: 40px auto;
+  padding: 20px;
+  text-align: center;
+}
+
+.block {
+  display: block;
+  margin-top: 20px;
+  margin-bottom: 10px;
+  font-weight: bold;
+}
+
+select, button {
+  font-size: 18px;
+  padding: 10px;
+  margin-top: 10px;
+}
+
+#number-selects label {
+  margin-top: 10px;
+  display: block;
+}
+
+pre {
+  text-align: left;
+  white-space: pre-wrap;
+  margin-top: 20px;
+  font-size: 18px;
+}


### PR DESCRIPTION
## Summary
- rename initial dropdown label to "System selection"
- always show 7-number combinations when clicking GO
- clarify usage in README

## Testing
- `# no tests to run`


------
https://chatgpt.com/codex/tasks/task_e_688b326b14148330ba6ba4d710a671b9